### PR TITLE
Support multi child device

### DIFF
--- a/core/class/broadlink.class.php
+++ b/core/class/broadlink.class.php
@@ -267,7 +267,7 @@ class broadlink extends eqLogic {
 	}
 	
 	public function preUpdate() {
-		if (substr($this->getLogicalId(), -3) != 'sub' && $this->getConfiguration('ischild',0) == 1) {
+		if (!preg_match('/.*?(-sub[0-9]*)$/', $this->getLogicalId()) && $this->getConfiguration('ischild',0) == 1) {
 			$this->setLogicalId($this->getLogicalId().'-sub');
 		}
 	}

--- a/resources/broadlinkd/broadlink/rm2.py
+++ b/resources/broadlinkd/broadlink/rm2.py
@@ -28,9 +28,9 @@ def learn_rm2(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	product = broadlink.gendevice(0x2712,host=(host,int(port)), mac=bytearray.fromhex(mac))
 	logging.debug("Connecting to Broadlink device with name " + name + "....")
@@ -66,9 +66,9 @@ def learn_rm2_rf(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	product = broadlink.gendevice(0x2712,host=(host,int(port)), mac=bytearray.fromhex(mac))
 	logging.debug("Connecting to Broadlink device with name " + name + "....")
@@ -123,9 +123,9 @@ def send_rm2(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	hex2send = device['hex2send']
 	product = broadlink.gendevice(0x2712,host=(host,int(port)), mac=bytearray.fromhex(mac))

--- a/resources/broadlinkd/broadlink/rm4.py
+++ b/resources/broadlinkd/broadlink/rm4.py
@@ -29,9 +29,9 @@ def learn_rm4(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	product = broadlink.gendevice(0x61a2,host=(host,int(port)), mac=bytearray.fromhex(mac))
 	logging.debug("Connecting to Broadlink device with name " + name + "....")
@@ -67,9 +67,9 @@ def learn_rm4_rf(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	product = broadlink.gendevice(0x61a2,host=(host,int(port)), mac=bytearray.fromhex(mac))
 	logging.debug("Connecting to Broadlink device with name " + name + "....")
@@ -124,9 +124,9 @@ def send_rm4(device):
 	host = device['ip']
 	port = device['port']
 	mac = device['mac']
-	if mac[-3:] == 'sub':
-		logging.debug("This is a child device original mac is " + mac[:-4])
-		mac = mac[:-4]
+	if '-sub' in mac:
+		logging.debug("This is a child device original mac is " + mac[:mac.find('-sub')])
+		mac = mac[:mac.find('-sub')]
 	name = device['name']
 	hex2send = device['hex2send']
 	product = broadlink.gendevice(0x61a2,host=(host,int(port)), mac=bytearray.fromhex(mac))

--- a/resources/broadlinkd/broadlinkd.py
+++ b/resources/broadlinkd/broadlinkd.py
@@ -102,7 +102,7 @@ def read_broadlink():
 			mac = globals.KNOWN_DEVICES[device]['mac']
 			if mac in globals.LAST_TIME_READ and now < (globals.LAST_TIME_READ[mac]+datetime.timedelta(milliseconds=int(globals.KNOWN_DEVICES[device]['delay'])*1000)):
 				continue
-			if mac[-3:] == 'sub':
+			if '-sub' in mac:
 				continue
 			else :
 				globals.LAST_TIME_READ[mac] = now


### PR DESCRIPTION
Bonjour,

ce changement permet de créer plusieurs "Sous-devices" pour les RM. Utile par exemple pour un RM qui se trouve dans le séjour, qui contrôle la clim en été, le chauffage en hiver, et la télé toute l'année. Permet de créer un équipement pour chaque fonction, avec un nombre de commandes réduit.

